### PR TITLE
Added Django specific version

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -9,7 +9,7 @@ webmin-apache
 
 python-pysqlite2
 
-python-django
+python-django=1.4.5
 libjs-jquery
 
 python-twisted          /* speeqe dependency */


### PR DESCRIPTION
Tried to fix the build error which required a specific function function which was present on in Django-1.4 below. But that particular package is not present in Debian repo. I guess we'll have to integrate "pip" installations for getting specific old versions.
